### PR TITLE
replace `awk` command with `gawk` for Debian Jessie

### DIFF
--- a/hershey_fonts/fix_linebreak.sh
+++ b/hershey_fonts/fix_linebreak.sh
@@ -4,4 +4,4 @@
 ## Removing "SUB" (0x1A), CR (Windows Carriage Return) and linebreaks in a glyph command.
 
 echo "removing unwanted linebreak and CR in $1"
-sed 's/\x1A//g' $1 | tr -d '\r' | awk --re-interval 'BEGIN{FIELDWIDTHS = "5 3 1 1 200"} $1~/[ 0-9]{5}/{if(NR>1) printf("\n")} {printf("%s",$0)}' > $2
+sed 's/\x1A//g' $1 | tr -d '\r' | gawk --re-interval 'BEGIN{FIELDWIDTHS = "5 3 1 1 200"} $1~/[ 0-9]{5}/{if(NR>1) printf("\n")} {printf("%s",$0)}' > $2


### PR DESCRIPTION
awk fails and throws error `awk: not an option: --re-interval`
despite it appearing in the usage print

Substituting `gawk` works correctly.

Signed-off-by: Mick <arceye@mgware.co.uk>